### PR TITLE
OverlayWindowの位置を指定できるようにする.

### DIFF
--- a/11Tube Music/Plugins/Overlay/OverlayWindow.xaml
+++ b/11Tube Music/Plugins/Overlay/OverlayWindow.xaml
@@ -7,28 +7,30 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
-    <Grid Padding="8" Opacity="0.6" Background="Transparent" x:Name="RootGrid">
-        <Grid.OpacityTransition >
-            <ScalarTransition Duration="0:0:0.2" />
-        </Grid.OpacityTransition>
-        <Grid.RowDefinitions>
-        <RowDefinition Height="Auto" />
-        <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-        <Border Height="48" Width="48" Grid.Column="0" Grid.Row="0" CornerRadius="4" Margin="8" VerticalAlignment="Top" Translation="0,0,48">
-            <Border.Shadow>
-                <ThemeShadow />
-            </Border.Shadow>
-            <Image Height="48" Width="48" Stretch="UniformToFill" x:Name="ThumbnailImage" />
-        </Border>
-        <StackPanel Grid.Column="1" Grid.Row="0" Padding="8">
-            <TextBlock Text="Unknown" x:Name="SongName" FontSize="20" />
-            <TextBlock Text="Unknown" x:Name="ArtistName" FontSize="15" />
-        </StackPanel>
-        <ProgressBar Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" x:Name="ProgressBar" Margin="16,8" Width="200" HorizontalAlignment="Left" />
-    </Grid>
+    <StackPanel Orientation="Vertical" HorizontalAlignment="Left" VerticalAlignment="Top" x:Name="RooStackPanel">
+        <Grid Padding="8" Opacity="0.6" Background="Transparent" x:Name="RootGrid">
+            <Grid.OpacityTransition >
+                <ScalarTransition Duration="0:0:0.2" />
+            </Grid.OpacityTransition>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Border Height="48" Width="48" Grid.Column="0" Grid.Row="0" CornerRadius="4" Margin="8" VerticalAlignment="Top" Translation="0,0,48">
+                <Border.Shadow>
+                    <ThemeShadow />
+                </Border.Shadow>
+                <Image Height="48" Width="48" Stretch="UniformToFill" x:Name="ThumbnailImage" />
+            </Border>
+            <StackPanel Grid.Column="1" Grid.Row="0" Padding="8">
+                <TextBlock Text="Unknown" x:Name="SongName" FontSize="20" />
+                <TextBlock Text="Unknown" x:Name="ArtistName" FontSize="15" />
+            </StackPanel>
+            <ProgressBar Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" x:Name="ProgressBar" Margin="16,8" Width="200" HorizontalAlignment="Left" />
+        </Grid>
+    </StackPanel>
 </Window>

--- a/11Tube Music/Plugins/Overlay/OverlayWindow.xaml.cs
+++ b/11Tube Music/Plugins/Overlay/OverlayWindow.xaml.cs
@@ -22,15 +22,47 @@ namespace ElevenTube_Music.Plugins.Overlay
 
             if (Options != null)
             {
-                PluginOption existingOption = Options.Find(option => option.Name == "opacity");
+                PluginOption opacityOption = Options.Find(option => option.Name == "opacity");
 
-
-                if (existingOption != null)
+                if (opacityOption != null)
                 {
-                    RootGrid.Opacity = double.Parse(existingOption.Value as string);
+                    RootGrid.Opacity = double.Parse(opacityOption.Value as string);
                 }
+
+
+                PluginOption positionOption = Options.Find(option => option.Name == "positon");
+
+                if (positionOption != null)
+                {
+                    string position = positionOption.Value as string;
+                    Debug.WriteLine("Overlaypositon_" + position);
+                    if (position == "TopLeft")
+                    {
+                        RooStackPanel.HorizontalAlignment = HorizontalAlignment.Left;
+
+                        RooStackPanel.VerticalAlignment = VerticalAlignment.Top;
+                    }
+                    else if (position == "TopRight")
+                    {
+                        RooStackPanel.HorizontalAlignment = HorizontalAlignment.Right;
+
+                        RooStackPanel.VerticalAlignment = VerticalAlignment.Top;
+                    }
+                    else if (position == "BottomLeft")
+                    {
+                        RooStackPanel.HorizontalAlignment = HorizontalAlignment.Left;
+
+                        RooStackPanel.VerticalAlignment = VerticalAlignment.Bottom;
+                    }
+                    else if (position == "BottomRight")
+                    {
+                        RooStackPanel.HorizontalAlignment = HorizontalAlignment.Right;
+
+                        RooStackPanel.VerticalAlignment = VerticalAlignment.Bottom;
+                    }
+                }
+
             }
-            
 
             var windowHandle = new IntPtr((long)this.AppWindow.Id.Value);
 

--- a/11Tube Music/Plugins/Overlay/config.json
+++ b/11Tube Music/Plugins/Overlay/config.json
@@ -2,7 +2,7 @@
   "type": "C#",
   "name": "Overlay",
   "description": "Show overlay on the screen.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "Clover_Midori",
     "contact": [
@@ -23,6 +23,17 @@
       "display_name": "Opacity",
       "placeholder": "default: 0.6",
       "description": "Opacity of the overlay. (0.0 ~ 1.0)"
+    },
+    {
+      "type": "combo",
+      "name": "positon",
+      "values": [
+        "TopLeft",
+        "TopRight",
+        "BottomLeft",
+        "BottomRight"
+      ],
+      "description": "Position of the Overlay"
     }
   ]
 }

--- a/11Tube Music/Plugins/Overlay/main.cs
+++ b/11Tube Music/Plugins/Overlay/main.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Windowing;
 using Vanara.PInvoke;
 using Windows.Graphics;
 using WinRT.Interop;
+using System.Windows.Forms;
 
 namespace ElevenTube_Music.Plugins.Overlay
 {
@@ -14,11 +15,15 @@ namespace ElevenTube_Music.Plugins.Overlay
 
         public void Main(MainWindow window, List<PluginOption> Options)
         {
+            int windowWidth = Screen.PrimaryScreen.WorkingArea.Width;
+
+            int windowHeight = Screen.PrimaryScreen.WorkingArea.Height;
+
             overlayWindow = new OverlayWindow(window, Options);
 
             overlayWindow.AppWindow.SetPresenter(AppWindowPresenterKind.FullScreen);
 
-            overlayWindow.AppWindow.MoveAndResize(new RectInt32(0, 0, 400, 100));
+            overlayWindow.AppWindow.MoveAndResize(new RectInt32(0, 0, windowWidth, windowHeight));
 
             window.Closed += (s, e) => overlayWindow.Close();
 

--- a/11Tube Music/Settings/Plugins.xaml.cs
+++ b/11Tube Music/Settings/Plugins.xaml.cs
@@ -164,6 +164,78 @@ namespace ElevenTube_Music.Settings
                             optionStackPanel.Children.Add(optionTextBox);
                         }
                     }
+                    else if (option.type == "combo")
+                    {
+                        ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
+                        string existingJson = (string)localSettings.Values[pluginConfig.name];
+                        Debug.WriteLine(existingJson);
+                        PluginSetting existingPluginSetting = null;
+                        if (existingJson != null)
+                        {
+                            existingPluginSetting = Newtonsoft.Json.JsonConvert.DeserializeObject<PluginSetting>(existingJson);
+                        }
+
+                        if (existingPluginSetting != null && existingPluginSetting.Options != null)
+                        {
+                            PluginOption existingOption = existingPluginSetting.Options.Find(o => o.Name == option.name);
+
+                            var optionComboBox = new ComboBox
+                            {
+                                Margin = new Thickness(8, 0, 0, 0),
+                                Tag = option.name
+                            };
+
+
+                            if (option.placeholder != null)
+                            {
+                                optionComboBox.PlaceholderText = option.placeholder;
+                            }
+
+                            if (option.values != null)
+                            {
+                                foreach (var value in option.values)
+                                {
+                                    optionComboBox.Items.Add(value);
+                                }
+                                int selectedIndex = Array.IndexOf(option.values, existingOption.Value);
+                                optionComboBox.SelectedIndex = selectedIndex >= 0 ? selectedIndex : 0;
+                            }
+
+                            optionComboBox.SelectionChanged += OptionComboBox_SelcetionChanged;
+
+                            options.Add(new PluginOption { Name = option.name, Value = optionComboBox.SelectedItem });
+
+                            optionStackPanel.Children.Add(optionComboBox);
+                        }
+                        else
+                        {
+                            var optionComboBox = new ComboBox
+                            {
+                                Margin = new Thickness(8, 0, 0, 0),
+                                Tag = option.name
+                            };
+                            if (option.placeholder != null)
+                            {
+                                optionComboBox.PlaceholderText = option.placeholder;
+                            }
+
+                            if (option.values != null)
+                            {
+                                foreach (var value in option.values)
+                                {
+                                    optionComboBox.Items.Add(value);
+                                }
+                                optionComboBox.SelectedIndex = 0;
+                            }
+
+                            optionComboBox.SelectionChanged += OptionComboBox_SelcetionChanged;
+
+                            // Add the option to the list
+                            options.Add(new PluginOption { Name = option.name, Value = optionComboBox.SelectedItem });
+
+                            optionStackPanel.Children.Add(optionComboBox);
+                        }
+                    }
 
                     optionCard.Content = optionStackPanel;
                     expander.Items.Add(optionCard);
@@ -251,6 +323,14 @@ namespace ElevenTube_Music.Settings
             TextBox textBox = (TextBox)sender;
             StackPanel parent = (StackPanel)VisualTreeHelper.GetParent(textBox);
             SaveOption(parent.Tag.ToString(),textBox.Tag.ToString(), textBox.Text);
+        }
+
+        private void OptionComboBox_SelcetionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            restartCard.Visibility = Visibility.Visible;
+            ComboBox comboBox = (ComboBox)sender;
+            StackPanel parent = (StackPanel)VisualTreeHelper.GetParent(comboBox);
+            SaveOption(parent.Tag.ToString(), comboBox.Tag.ToString(), comboBox.SelectedItem);
         }
 
         private static PluginSetting ConvertToNewFormat(bool enable, bool oldFormat, List<PluginOption> oldOptions)

--- a/11Tube Music/Types/Plugin.cs
+++ b/11Tube Music/Types/Plugin.cs
@@ -50,6 +50,7 @@ namespace ElevenTube_Music.Types
         public string? placeholder { get; set; }
 #nullable disable
         public string description { get; set; }
-
+#nullable enable
+        public string[]? values { get; set; }
     }
 }


### PR DESCRIPTION
ブランチの設定を間違えていたため再プルリクです。
Overlay Windowの位置を指定できるようにしました。
選択可能な位置は、TopLeft , TopRight , BottomLeft , BottomRightの４つです。

また、それにより、
Combo Box を Plugin Optionで使えるようにしました。
typeに"combo"を指定してvaluesにstring[]を指定すると使えます