### PR TITLE
DiscordRPC Pluginでエラーが起きた際、それ以下のプラグインが実行されないバグの修正

### DIFF
--- a/11Tube Music/Plugins.cs
+++ b/11Tube Music/Plugins.cs
@@ -61,7 +61,7 @@ namespace ElevenTube_Music
                                 {
                                     PluginSetting pluginSetting = JsonConvert.DeserializeObject<PluginSetting>(localSettings.Values[pluginName].ToString());
                                     ParameterInfo[] parameters = method.GetParameters();
-                                    if(parameters[1] != null)
+                                    if(parameters.Length>=2 && parameters[1] != null)
                                     {
                                         object instance = Activator.CreateInstance(pluginType);
                                         object[] methodParams = new object[] { this, pluginSetting.Options };


### PR DESCRIPTION
parametersの範囲外アクセスが原因でした。