### PR TITLE
ユーザーがブラウザ側のシークバーを操作したときアプリ側に反映されない不具合を修正

### DIFF
--- a/11Tube Music/Plugins/Overlay/OverlayWindow.xaml.cs
+++ b/11Tube Music/Plugins/Overlay/OverlayWindow.xaml.cs
@@ -138,6 +138,7 @@ namespace ElevenTube_Music.Plugins.Overlay
         {
             if (IsPaused.paused)
             {
+                ProgressBar.Value = IsPaused.currentTime;
                 timer.Stop();
             }
             else

--- a/11Tube Music/preload.js
+++ b/11Tube Music/preload.js
@@ -53,6 +53,17 @@ function setupVideoEventListeners(video) {
         };
         window.chrome.webview.postMessage(data);
     };
+    video.onseeking = async () => {
+        rawData = {
+            paused: video.paused,
+            currentTime: video.currentTime,
+        }
+        const data = {
+            type: 'isPaused',
+            data: rawData
+        };
+        window.chrome.webview.postMessage(data);
+    }
 }
 
 function setupLoadstartEventListener(video, api) {


### PR DESCRIPTION
Video の seeking eventを受け取った際にもisPausedを発火させるようにしました。