### PR TITLE
Solved the problem of going back a second when using MiniPlayer.

### DIFF
--- a/11Tube Music/Plugins/MiniPlayer/MiniPlayer.xaml.cs
+++ b/11Tube Music/Plugins/MiniPlayer/MiniPlayer.xaml.cs
@@ -174,7 +174,7 @@ namespace ElevenTube_Music.Plugins.MiniPlayer
 
         private void HandleSeekBarChanged(object sender, RangeBaseValueChangedEventArgs e)
         {
-            if(Math.Abs(e.NewValue - e.OldValue) > 1)
+            if(Math.Round(Math.Abs(e.NewValue - e.OldValue)) > 1)
             {
                 mainWindow.SetPlayerSeek((int)e.NewValue);
             }

--- a/11Tube Music/Plugins/MiniPlayer/MiniPlayer.xaml.cs
+++ b/11Tube Music/Plugins/MiniPlayer/MiniPlayer.xaml.cs
@@ -174,7 +174,7 @@ namespace ElevenTube_Music.Plugins.MiniPlayer
 
         private void HandleSeekBarChanged(object sender, RangeBaseValueChangedEventArgs e)
         {
-            if(Math.Abs(e.NewValue - e.OldValue) > 1)
+            if(Math.Abs(e.NewValue - e.OldValue) > 1.1)
             {
                 mainWindow.SetPlayerSeek((int)e.NewValue);
             }


### PR DESCRIPTION
言語の都合上偶に小数点以下の計算がおかしくなることがあるので、四捨五入することで対処しました。